### PR TITLE
[CLIENT-6489] Use enableRingingState

### DIFF
--- a/public/quickstart.js
+++ b/public/quickstart.js
@@ -22,6 +22,13 @@
         // but the client-side DTMF tones are fake. This prevents the local mic capturing the DTMF tone
         // a second time and sending the tone twice. This will be default in 2.0.
         fakeLocalDTMF: true,
+        // Use `enableRingingState` to enable the device to emit the `ringing`
+        // state. The TwiML backend also needs to have the attribute
+        // `answerOnBridge` also set to true in the `Dial` verb. This option
+        // changes the behavior of the SDK to consider a call `ringing` starting
+        // from the connection to the TwiML backend to when the recipient of
+        // the `Dial` verb answers.
+        enableRingingState: true,
       });
 
       device.on('ready',function (device) {
@@ -84,7 +91,10 @@
 
     console.log('Calling ' + params.To + '...');
     if (device) {
-      device.connect(params);
+      var outgoingConnection = device.connect(params);
+      outgoingConnection.on('ringing', function() {
+        log('Ringing...');
+      });
     }
   };
 


### PR DESCRIPTION
Update the quickstart to support the `ringing` state by default.